### PR TITLE
Fix RLE underflow in send_slices_D4 causing ghost samples

### DIFF
--- a/pico_sdk_sigrok/pico_sdk_sigrok.c
+++ b/pico_sdk_sigrok/pico_sdk_sigrok.c
@@ -307,6 +307,7 @@ uint32_t send_slices_D4(sr_device_t *d,uint8_t *dbuf){
     if(rlecnt>7) {
       int rleend=rlecnt&0x3F8;
       txbuf[txbufidx++]=(rleend>>3)+47;
+      rlecnt -= rleend;
     }
     //1..7 RLE 
     //The rle and value encoding counts as both a sample count of rle and a new sample


### PR DESCRIPTION
This PR fixes the RLE integer underflow bug described in Issue #75.

**Changes:**
- Added `rlecnt -= rleend;` in `send_slices_D4()` to properly update the run-length counter when sending residual middle RLEs (8..632). 

This prevents `rlecnt` from incorrectly evaluating to `0` and underflowing in the subsequent 1..7 RLE block, which previously caused the injection of 8 false samples into the USB stream. Tested and confirmed on hardware (the +8µs/+9µs artifacts are entirely eliminated).