### PR TITLE
Add includes for stdlib and bootrom in sr_device.c - fix sleep_ms and rom_reset_usb_boot make errors

### DIFF
--- a/pico_sdk_sigrok/sr_device.c
+++ b/pico_sdk_sigrok/sr_device.c
@@ -1,3 +1,5 @@
+#include "pico/stdlib.h"
+#include "pico/bootrom.h"
 #include "sr_device.h"
 #include "hardware/uart.h"
 


### PR DESCRIPTION
Added compatability for ubuntu make.

Without these lines I got errors:


```
[ 13%] Completed 'picotoolBuild'
[ 13%] Built target picotoolBuild
[ 14%] Building C object CMakeFiles/pico_sdk_sigrok.dir/pico_sdk_sigrok.c.o
[ 14%] Building C object CMakeFiles/pico_sdk_sigrok.dir/sr_device.c.o
/home/xxxxxxxx/sigrok-pico/pico_sdk_sigrok/sr_device.c: In function 'process_char':
/home/xxxxxxxx/sigrok-pico/pico_sdk_sigrok/sr_device.c:133:13: error: implicit declaration of function 'sleep_ms' [-Wimplicit-function-declaration]
  133 |             sleep_ms(1000);
      |             ^~~~~~~~
/home/xxxxxxxx/sigrok-pico/pico_sdk_sigrok/sr_device.c:135:13: error: implicit declaration of function 'rom_reset_usb_boot' [-Wimplicit-function-declaration]
  135 |             rom_reset_usb_boot(0,0);
      |             ^~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/pico_sdk_sigrok.dir/build.make:93: CMakeFiles/pico_sdk_sigrok.dir/sr_device.c.o] Ошибка 1
make[1]: *** [CMakeFiles/Makefile2:2306: CMakeFiles/pico_sdk_sigrok.dir/all] Ошибка 2
make: *** [Makefile:91: all] Ошибка 2

```

Ubuntu 25.04
Linux 6.14.0-29-generic
64 bit